### PR TITLE
Add analytics functionality and data structure for sales by location

### DIFF
--- a/src/pages/Dashboard/Admin/Analytics/Analytics.jsx
+++ b/src/pages/Dashboard/Admin/Analytics/Analytics.jsx
@@ -1,8 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Users, Home, Eye, DollarSign } from 'lucide-react';
 import StatCard from './components/StatCard';
 import DynamicChart from './components/DynamicChart';
-import { salesData, propertyTypeData, COLORS, stats as statsData } from '../../../../shared/utils/data';
+import {
+  salesData,
+  propertyTypeData,
+  COLORS,
+  stats as statsData,
+  ventasData, // ← ya normalizado
+} from '../../../../shared/utils/data';
 
 const iconMap = {
   Eye,
@@ -11,15 +17,68 @@ const iconMap = {
   DollarSign,
 };
 
+// Obtener sedes desde los keys del objeto ventasData
+const sedes = Object.keys(ventasData);
+
+// 🧠 Función que agrupa y suma por mes
+const agruparPorMes = data => {
+  const resultado = {};
+
+  data.forEach(({ month, ventas, rentas }) => {
+    if (!resultado[month]) {
+      resultado[month] = { month, ventas: 0, rentas: 0 };
+    }
+    resultado[month].ventas += ventas;
+    resultado[month].rentas += rentas;
+  });
+
+  const ordenMeses = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun'];
+  return ordenMeses.map(m => resultado[m]).filter(Boolean);
+};
+
 const Analytics = () => {
+  const [sede, setSede] = useState('');
+
+  // Si hay sede seleccionada, se toma directamente
+  // Si no, se agrupan todos los datos por mes con sumatoria
+  const allData = sedes.flatMap(s => ventasData[s]);
+  const chartSalesData = sede
+    ? ventasData[sede] || []
+    : agruparPorMes(allData);
+
   return (
     <div className="p-4 sm:p-6 lg:p-8 bg-gray-100 dark:bg-gray-900 min-h-screen">
+
+      <div className='flex justify-between items-center mb-6'>
+
+   
       <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
-        Dashboard de Análisis
+        Dashboard de Análisis  
       </h1>
+ 
+        {/* Selección de sede */}
+      <div className="flex gap-2 items-end">
+        <p className="text-gray-900 dark:text-gray-100 text-2xl">Selecciona la Sede</p>
+        <select
+          className="border border-gray-300 rounded-md p-2"
+          value={sede}
+          onChange={e => setSede(e.target.value)}
+        >
+          <option value="">Todas</option>
+          {sedes.map(s => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+      </div> 
+
+         </div>
+
+
+
 
       {/* Sección de Tarjetas de Estadísticas */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+        
         {statsData.map((stat, index) => (
           <StatCard
             key={index}
@@ -31,10 +90,13 @@ const Analytics = () => {
         ))}
       </div>
 
+  
       {/* Sección de Gráficas */}
       <div className="grid grid-cols-1 gap-8">
+
+        
         <DynamicChart
-          salesData={salesData}
+          salesData={chartSalesData}
           propertyTypeData={propertyTypeData}
           colors={COLORS}
         />

--- a/src/shared/utils/data.js
+++ b/src/shared/utils/data.js
@@ -371,13 +371,40 @@ export const reviews = [
 ];
 
 export const salesData = [
-  { month: 'Ene', ventas: 40, rentas: 24 },
+  { month: 'Ene',ventas: 40, rentas: 24  },
   { month: 'Feb', ventas: 30, rentas: 14 },
   { month: 'Mar', ventas: 20, rentas: 58 },
   { month: 'Abr', ventas: 27, rentas: 39 },
   { month: 'May', ventas: 18, rentas: 48 },
   { month: 'Jun', ventas: 23, rentas: 38 },
 ];
+
+export const ventasData = {
+  'Sede 1': [
+    { month: 'Ene', ventas: 40, rentas: 24 },
+    { month: 'Feb', ventas: 30, rentas: 14 },
+    { month: 'Mar', ventas: 20, rentas: 58 },
+    { month: 'Abr', ventas: 27, rentas: 39 },
+    { month: 'May', ventas: 18, rentas: 48 },
+    { month: 'Jun', ventas: 23, rentas: 38 },
+  ],
+  'Sede 2': [
+    { month: 'Ene', ventas: 35, rentas: 20 },
+    { month: 'Feb', ventas: 25, rentas: 10 },
+    { month: 'Mar', ventas: 15, rentas: 50 },
+    { month: 'Abr', ventas: 22, rentas: 35 },
+    { month: 'May', ventas: 12, rentas: 45 },
+    { month: 'Jun', ventas: 20, rentas: 30 },
+  ],
+  'Sede 3': [
+    { month: 'Ene', ventas: 50, rentas: 30 },
+    { month: 'Feb', ventas: 40, rentas: 20 },
+    { month: 'Mar', ventas: 30, rentas: 60 },
+    { month: 'Abr', ventas: 35, rentas: 45 },
+    { month: 'May', ventas: 25, rentas: 55 },
+    { month: 'Jun', ventas: 30, rentas: 40 },
+  ],
+};
 
 export const propertyTypeData = [
   { name: 'Casas', value: 400 },


### PR DESCRIPTION
This pull request enhances the `Analytics` dashboard by introducing support for filtering sales and rental data by location (`sede`) and aggregating data across all locations when no specific location is selected. It also updates the chart data handling to reflect these changes. Below are the key changes:

### New Features for Data Filtering and Aggregation:
- Added a dropdown menu to select a specific `sede` (location) or view aggregated data for all locations. This is implemented using a new `useState` hook to manage the selected `sede`. (`[src/pages/Dashboard/Admin/Analytics/Analytics.jsxR20-R81](diffhunk://#diff-c626a50a6ee20b565479c7951d1194b768a6117bdd238fcf6a2fe561711b92c5R20-R81)`)
- Introduced the `agruparPorMes` function, which aggregates sales and rental data by month across all locations. This ensures accurate data representation when no specific `sede` is selected. (`[src/pages/Dashboard/Admin/Analytics/Analytics.jsxR20-R81](diffhunk://#diff-c626a50a6ee20b565479c7951d1194b768a6117bdd238fcf6a2fe561711b92c5R20-R81)`)

### Updates to Data Handling:
- Replaced the static `salesData` with a new `ventasData` object in `src/shared/utils/data.js`, which organizes sales and rental data by `sede`. (`[src/shared/utils/data.jsR382-R408](diffhunk://#diff-7e66ef04564fa2a78fd6c67224db7a0265a60a9f6fd0ed19b480e43d94fe7b80R382-R408)`)
- Updated the `DynamicChart` component to use the dynamically filtered or aggregated `chartSalesData` instead of the previously hardcoded `salesData`. (`[src/pages/Dashboard/Admin/Analytics/Analytics.jsxR93-R99](diffhunk://#diff-c626a50a6ee20b565479c7951d1194b768a6117bdd238fcf6a2fe561711b92c5R93-R99)`)

### UI Enhancements:
- Added a new UI section in the `Analytics` dashboard for selecting a `sede` via a dropdown menu. The dropdown includes an option for "Todas" (all locations) and dynamically populates options based on available `sedes`. (`[src/pages/Dashboard/Admin/Analytics/Analytics.jsxR20-R81](diffhunk://#diff-c626a50a6ee20b565479c7951d1194b768a6117bdd238fcf6a2fe561711b92c5R20-R81)`)