### PR TITLE
feat: add HomeButton component and integrate it into multiple pages

### DIFF
--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -2,19 +2,21 @@ import { NavLink } from "react-router-dom";
 import { useState } from "react";
 import { Menu, X, CircleUserRound } from "lucide-react";
 import { navItems } from "../../data/navItems";
-
+import HomeButton from "./HomeButton";
 const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <header className="bg-[#2D3A4E] shadow sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 py-3 flex relative items-center h-16">
-        {/* Logo */}
+        {/* Logo
         <NavLink to="/">
           <div className="flex items-center gap-2 left-4">
             <h1 className="text-xl font-bold text-white">JustHome</h1>
           </div>
-        </NavLink>
+        </NavLink> */}
+
+        <HomeButton />
 
         {/* Desktop nav con íconos */}
         <nav className="hidden lg:flex gap-10 text-base font-medium mx-auto">

--- a/src/components/ui/HomeButton.jsx
+++ b/src/components/ui/HomeButton.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { NavLink } from "react-router-dom";
+
+
+const HomeButton = () => {
+  return (
+    <div>
+          {/* Logo */}
+        <NavLink to="/">
+          <div className="flex items-center gap-2 left-4">
+            {/* <h1 className="text-xl font-bold text-white">JustHome</h1> */}
+            <img src="/img/logo_justhome.png" alt="JustHome Logo" className="h-10 w-auto" />
+          </div>
+        </NavLink>
+        </div>
+  )
+}
+
+export default HomeButton

--- a/src/pages/Login/ForgotPassword.jsx
+++ b/src/pages/Login/ForgotPassword.jsx
@@ -1,6 +1,7 @@
 import Card from "../../../src/components/ui/Card";
 import Button from "../../components/ui/Button";
 import { toast, Toaster } from "react-hot-toast";
+import HomeButton from "../../components/ui/HomeButton";
 
 const ForgotPassword = () => {
 
@@ -22,7 +23,9 @@ return(
     
     {/* Fondo dividido */}
     <div className="absolute top-6 left-6 z-20">
-      <img src="/img/logo_justhome.png" alt="JustHome Logo" className="h-10 w-auto" />
+      {/* <img src="/img/logo_justhome.png" alt="JustHome Logo" className="h-10 w-auto" /> */}
+      <HomeButton/>
+
     </div>
     <div className="absolute top-0 w-full h-full flex flex-col">
       <div className="lg:h-1/2 h-full flex bg-[#1E2A3A] relative justify-center pr-96">

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -2,13 +2,16 @@ import FormSingIn from "./components/FormSingIn";
 import Button from "../../../src/components/ui/Button";
 import { Link } from "react-router-dom";
 import Card from "../../../src/components/ui/Card";
+import HomeButton from "../../components/ui/HomeButton";
 const Login = () => {
 
   return (
     <div className="relative h-screen w-full">
       {/* Fondo dividido */}
       <div className="absolute top-6 left-6 z-20">
-        <img src="/img/logo_justhome.png" alt="JustHome Logo" className="h-10 w-auto" />
+        {/* <img src="/img/logo_justhome.png" alt="JustHome Logo" className="h-10 w-auto" /> */}
+      <HomeButton />
+      
       </div>
       <div className="absolute top-0 w-full h-full flex flex-col">
         <div className="lg:h-1/2 h-full flex bg-[#1E2A3A] relative justify-center pr-96">

--- a/src/pages/Register/Register.jsx
+++ b/src/pages/Register/Register.jsx
@@ -1,12 +1,14 @@
 import { Link } from "react-router-dom";
 import FormSignUp from "./components/FormSignUp";
 import Card from "../../components/ui/Card";
+import HomeButton from "../../components/ui/HomeButton";
 
 const Register = () => {
   return (
     <main className="relative min-h-screen w-full bg-brand-dark md:bg-transparent">
       <div className="absolute top-6 left-6 z-20">
-        <img src="/img/logo_justhome.png" alt="JustHome Logo" className="h-10 w-auto" />
+        {/* <img src="/img/logo_justhome.png" alt="JustHome Logo" className="h-10 w-auto" /> */}
+        <HomeButton />
       </div>
       <div className="hidden md:flex items-center justify-start absolute top-0 left-0 w-full h-1/2 bg-brand-dark p-12">
         <img src="/img/rocket.png" alt="Rocket Launch" className="hidden xl:block h-4/5 w-auto object-contain" />


### PR DESCRIPTION
# Pull Request – Refactorización del logo y navegación de JustHome

Este *pull request* refactoriza cómo se manejan el logo de **JustHome** y la navegación hacia la página principal en toda la aplicación.  

La mejora principal es la introducción de un componente reutilizable `HomeButton`, que centraliza la lógica del logo y del enlace a la página principal, reemplazando código repetido y facilitando futuras actualizaciones.  

El uso del logo en las páginas de **inicio de sesión**, **registro** y **restablecimiento de contraseña** ahora utiliza de forma consistente este nuevo componente.  

---

## 🔹 Reutilización de componentes y refactorización

- Se agregó un nuevo componente `HomeButton` que encapsula el logo de JustHome y el enlace a la página principal, reemplazando el código duplicado de logo/enlace en toda la aplicación.  
  - `src/components/ui/HomeButton.jsx`

- Se actualizó el componente `Header` para usar el nuevo `HomeButton` en lugar del marcado inline de logo/enlace.  
  - `src/components/ui/Header.jsx`

- Se refactorizaron las páginas de inicio de sesión, registro y recuperación de contraseña para usar `HomeButton` en lugar de la imagen de logo y enlace inline anteriores.  
  - `src/pages/Login/Login.jsx`  
  - `src/pages/Register/Register.jsx`  
  - `src/pages/Login/ForgotPassword.jsx`
